### PR TITLE
Golang example. Fix incorrect handler name. Now receive handeler works correctly

### DIFF
--- a/projects/Go/examples/send_receive.go
+++ b/projects/Go/examples/send_receive.go
@@ -1,7 +1,10 @@
 package main
 
-import "fmt"
-import "../proto/proto"
+import (
+	"fmt"
+
+	"../proto/proto"
+)
 
 type MySender struct {
 	*proto.Sender
@@ -32,9 +35,9 @@ func NewMyReceiver() *MyReceiver {
 	return receiver
 }
 
-func (r *MyReceiver) OnReceiveOrder(value *proto.OrderMessage) {}
-func (r *MyReceiver) OnReceiveBalance(value *proto.BalanceMessage) {}
-func (r *MyReceiver) OnReceiveAccount(value *proto.AccountMessage) {}
+func (r *MyReceiver) OnReceiveOrderMessage(value *proto.OrderMessage)     {}
+func (r *MyReceiver) OnReceiveBalanceMessage(value *proto.BalanceMessage) {}
+func (r *MyReceiver) OnReceiveAccountMessage(value *proto.AccountMessage) {}
 
 func (r *MyReceiver) OnReceiveLog(message string) {
 	fmt.Printf("onReceive: %s\n", message)


### PR DESCRIPTION
Golang handler names was incorrect 

Here you can see it looking for `OnReceiveOrderMessage`, but in example the name is `OnReceiveOrder`

https://github.com/chronoxor/FastBinaryEncoding/blob/master/projects/Go/proto/proto/Receiver.go#L95